### PR TITLE
System header file include guards

### DIFF
--- a/programs/libBareMetal.h
+++ b/programs/libBareMetal.h
@@ -8,8 +8,8 @@
 //
 // This allows for a C/C++ program to access OS functions available in BareMetal OS
 // =============================================================================
-#ifndef LIBBAREMETAL_INC
-#define LIBBAREMETAL_INC
+#ifndef _LIBBAREMETAL_H
+#define _LIBBAREMETAL_H 1
 
 void b_output(const char *str);
 void b_output_chars(const char *str, unsigned long nbr);


### PR DESCRIPTION
A user could have `LIBBAREMETAL_INC` already defined when they include the **libBareMetal.h** file; this would result in a name collision for the define. In order to lessen the chance of such a collision, an underscore should be prepended to the define names: users following the C standard will avoid defining prepended names, thus preventing a define name collision.